### PR TITLE
fix: set default messaging network to testnet

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -13,7 +13,7 @@
     }
   },
   "logLevel": "info",
-  "network": "mainnet",
+  "network": "testnet",
   "mnemonic": "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
   "swapPools": [
     {


### PR DESCRIPTION
https://discord.com/channels/454734546869551114/816703710859100211/880173432715739219

Given `mainnet` will be used for non-test activities in the future, it makes sense to default this to `testnet` for testnet users now. 