### PR TITLE
Add loki support

### DIFF
--- a/data/grafanaConfig/dashboards/Container-Logs.json
+++ b/data/grafanaConfig/dashboards/Container-Logs.json
@@ -1,0 +1,294 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1638203608247,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "panels": [],
+      "repeat": "container",
+      "scopedVars": {
+        "container": {
+          "selected": false,
+          "text": "web3signer:develop",
+          "value": "web3signer:develop"
+        }
+      },
+      "title": "$container",
+      "type": "row"
+    },
+    {
+      "datasource": "loki",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "pluginVersion": "7.3.5",
+      "scopedVars": {
+        "container": {
+          "selected": false,
+          "text": "web3signer:develop",
+          "value": "web3signer:develop"
+        }
+      },
+      "targets": [
+        {
+          "expr": "{job=\"containerlogs\", container_name=~\".*/$container\"}",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Full Logs",
+      "type": "logs"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 7,
+      "panels": [],
+      "repeatIteration": 1638203608247,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "container": {
+          "selected": false,
+          "text": "nxtp-router:latest",
+          "value": "nxtp-router:latest"
+        }
+      },
+      "title": "$container",
+      "type": "row"
+    },
+    {
+      "datasource": "loki",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 8,
+      "options": {
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "pluginVersion": "7.3.5",
+      "repeatIteration": 1638203608247,
+      "repeatPanelId": 6,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "container": {
+          "selected": false,
+          "text": "nxtp-router:latest",
+          "value": "nxtp-router:latest"
+        }
+      },
+      "targets": [
+        {
+          "expr": "{job=\"containerlogs\", container_name=~\".*/$container\"}",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Full Logs",
+      "type": "logs"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 9,
+      "panels": [],
+      "repeatIteration": 1638203608247,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "container": {
+          "selected": false,
+          "text": "logspout:v1.2.0",
+          "value": "logspout:v1.2.0"
+        }
+      },
+      "title": "$container",
+      "type": "row"
+    },
+    {
+      "datasource": "loki",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 10,
+      "options": {
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "pluginVersion": "7.3.5",
+      "repeatIteration": 1638203608247,
+      "repeatPanelId": 6,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "container": {
+          "selected": false,
+          "text": "logspout:v1.2.0",
+          "value": "logspout:v1.2.0"
+        }
+      },
+      "targets": [
+        {
+          "expr": "{job=\"containerlogs\", container_name=~\".*/$container\"}",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Full Logs",
+      "type": "logs"
+    }
+  ],
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [
+    "Logs"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "loki",
+        "definition": "label_values(container_name)",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "container",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "web3signer:develop",
+            "value": "web3signer:develop"
+          },
+          {
+            "selected": false,
+            "text": "nxtp-router:latest",
+            "value": "nxtp-router:latest"
+          },
+          {
+            "selected": false,
+            "text": "logspout:v1.2.0",
+            "value": "logspout:v1.2.0"
+          }
+        ],
+        "query": "label_values(container_name)",
+        "refresh": 0,
+        "regex": ".*/(.*)",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Containers Logs",
+  "uid": null,
+  "version": 0
+}

--- a/data/grafanaConfig/grafana/provisioning/datasources/datasources.yaml
+++ b/data/grafanaConfig/grafana/provisioning/datasources/datasources.yaml
@@ -5,3 +5,7 @@ datasources:
     type: prometheus
     access: proxy
     url: http://prometheus:9090
+  - name: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100

--- a/data/lokiConfig/config.yml
+++ b/data/lokiConfig/config.yml
@@ -1,0 +1,27 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+

--- a/data/promtailConfig/config.yml
+++ b/data/promtailConfig/config.yml
@@ -1,0 +1,42 @@
+server:
+  disable: true
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+
+- job_name: containers
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: containerlogs
+      __path__: /var/lib/docker/containers/*/*log
+
+  pipeline_stages:
+  - json:
+      expressions:
+        output: log
+        stream: stream
+        attrs:
+  - json:
+      expressions:
+        tag:
+      source: attrs
+  - regex:
+      expression: (?P<container_name>(?:[^|]*[^|]))
+      source: tag
+  - timestamp:
+      format: RFC3339Nano
+      source: time
+  - labels:
+      # tag:
+      stream:
+      container_name:
+  - output:
+      source: output
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       driver: json-file
       options:
         max-size: 10m
+        tag: "{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}"
     networks:
       - nxtp
 
@@ -30,6 +31,7 @@ services:
       driver: json-file
       options:
         max-size: 10m
+        tag: "{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}"
     networks:
       - nxtp
 
@@ -48,6 +50,7 @@ services:
       driver: json-file
       options:
         max-size: 10m
+        tag: "{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}"
     networks:
       - nxtp
 
@@ -85,6 +88,34 @@ services:
       - ./data/grafanaConfig/grafana:/etc/grafana
       - ./data/grafanaConfig/dashboards:/etc/dashboards
       - grafana:/var/lib/grafana
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+    networks:
+      - nxtp
+
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/config.yml
+    volumes:
+      - ./data/lokiConfig:/etc/loki
+      - loki:/loki
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+    networks:
+      - nxtp
+
+  promtail:
+    image: grafana/promtail:latest
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers
+      - ./data/promtailConfig/config.yml:/etc/promtail/promtail.yml
+    command: -config.file=/etc/promtail/promtail.yml
     logging:
       driver: json-file
       options:
@@ -154,3 +185,5 @@ networks:
 volumes:
   prometheus:
   grafana:
+  loki:
+


### PR DESCRIPTION
It can be useful to have grafana dashboard with logdna/router/signer logs.
This PR adds loki stack to current docker-compose + dashboard with logs.