### PR TITLE
Add alertmanager discord support.

### DIFF
--- a/data/alertmanagerConfig/alertmanager.yml
+++ b/data/alertmanagerConfig/alertmanager.yml
@@ -1,0 +1,12 @@
+# The root route on which each incoming alert enters.
+route:
+  group_by: ['alertname']
+  group_wait: 20s
+  group_interval: 5m
+  repeat_interval: 3h
+  receiver: discord_webhook
+
+receivers:
+  - name: 'discord_webhook'
+    webhook_configs:
+      - url: 'http://alertmanager-discord:9094'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,36 @@ services:
     networks:
       - nxtp
 
+  alertmanager:
+    image: prom/alertmanager
+    restart: always
+    volumes:
+      - ./data/alertmanagerConfig:/config
+      - alertmanager:/data
+    command:
+      - --config.file=/config/alertmanager.yml
+    ports:
+      - 9093:9093
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+    networks:
+      - nxtp
+
+  alertmanager-discord:
+    container_name: alertmanager-discord
+    image: benjojo/alertmanager-discord
+    restart: always
+    environment:
+      DISCORD_WEBHOOK: $DISCORD_WEBHOOK
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+    networks:
+      - nxtp
+
   ################################################################################
 
   node-exporter:
@@ -194,4 +224,5 @@ volumes:
   grafana:
   loki:
   redis_data:
+  alertmanager:
 


### PR DESCRIPTION
Alertmanager is used to send alerts originating from prometheus service. 

This configuration will include the alartmanager-discord service and utilize the existing DISCORD_WEBHOOK variable in .env file.
