### PR TITLE
Change router's port in prometheus's target

### DIFF
--- a/data/prometheusConfig/prometheus.yml
+++ b/data/prometheusConfig/prometheus.yml
@@ -32,6 +32,6 @@ scrape_configs:
       labels:
         server: PRODUCTION
     - targets:
-      - 'router:8080'
+      - 'router:8000'
       labels:
         server: PRODUCTION


### PR DESCRIPTION
Based on the defined external port in `.env.example`, it should be same as 8000